### PR TITLE
Updated lab unguided doc with Auditor user role

### DIFF
--- a/Hands-on lab/Hands-on lab unguided - Azure Blockchain.md
+++ b/Hands-on lab/Hands-on lab unguided - Azure Blockchain.md
@@ -374,8 +374,8 @@ In this exercise, the student will create some additional Users within Azure AD 
     | Contoso Shipping               | User |
     | Blockchain Shipping            | User |
     | Simulated Device               | User |
-    | Government Regulator           | User |
     | Northwind Traders Supplychain  | User |
+    | Government Regulator           | Auditor |
 
 ## Exercise 6: Create and Process an Instance of the Smart Contract
 


### PR DESCRIPTION
Updated the unguided lab doc with the change for the "Government Regulator" user to be assigned to the "Auditor" role for the Smart Contract.